### PR TITLE
add attribute connection limit to config of virtual server

### DIFF
--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -114,6 +114,12 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 				Description:   "Specifies destination traffic matching information to which the virtual server sends traffic",
 				ConflictsWith: []string{"destination", "port"},
 			},
+			"connection_limit": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the maximum number of connections allowed for the virtual server.",
+				Computed:    true,
+			},
 			"pool": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -359,6 +365,7 @@ func resourceBigipLtmVirtualServerRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	_ = d.Set("trafficmatching_criteria", vs.TrafficMatchingCriteria)
+	_ = d.Set("connection_limit", vs.ConnectionLimit)
 	_ = d.Set("source", vs.Source)
 	_ = d.Set("ip_protocol", vs.IPProtocol)
 	_ = d.Set("name", name)
@@ -588,6 +595,7 @@ func getVirtualServerConfig(d *schema.ResourceData, config *bigip.VirtualServer)
 	config.Vlans = vlans
 	config.IPProtocol = d.Get("ip_protocol").(string)
 	config.TrafficMatchingCriteria = d.Get("trafficmatching_criteria").(string)
+    config.ConnectionLimit = connectionLimit.(int)
 	srcAddrsTrans := struct {
 		Type string `json:"type,omitempty"`
 		Pool string `json:"pool,omitempty"`

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -60,6 +60,7 @@ resource "bigip_ltm_virtual_server" "test-vs" {
 	default_persistence_profile = "/Common/hash"
 	fallback_persistence_profile = "/Common/dest_addr"
     policies = [bigip_ltm_policy.http_to_https_redirect.name]
+	connection_limit = 100
 }
 `
 var TestVs6Name = fmt.Sprintf("/%s/test-vs6", TestPartition)
@@ -80,6 +81,7 @@ resource "bigip_ltm_virtual_server" "test-vs" {
 	persistence_profiles = ["/Common/source_addr", "/Common/hash"]
 	default_persistence_profile = "/Common/hash"
 	fallback_persistence_profile = "/Common/dest_addr"
+	connection_limit = 200
 }
 `
 
@@ -112,6 +114,7 @@ func TestAccBigipLtmVirtualServerCreateV4V6(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("bigip_ltm_virtual_server.test-vs", "server_profiles.*", "/Common/tcp-lan-optimized"),
 					resource.TestCheckTypeSetElemAttr("bigip_ltm_virtual_server.test-vs", "persistence_profiles.*", "/Common/source_addr"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "fallback_persistence_profile", "/Common/dest_addr"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "connection_limit", "100"),
 				),
 			},
 		},
@@ -148,6 +151,7 @@ func TestAccBigipLtmVirtualServerCreateV4V6(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("bigip_ltm_virtual_server.test-vs", "persistence_profiles.*", "/Common/source_addr"),
 					resource.TestCheckTypeSetElemAttr("bigip_ltm_virtual_server.test-vs", "persistence_profiles.*", "/Common/hash"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "fallback_persistence_profile", "/Common/dest_addr"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "connection_limit", "200"),
 				),
 			},
 		},


### PR DESCRIPTION
Add attribute connection limit to config of virtual server
This attribute exists in the provider for node but not in vserver